### PR TITLE
Set character limits on exception_class and severity

### DIFF
--- a/lib/generators/solid_errors/install/templates/create_solid_errors_tables.rb.erb
+++ b/lib/generators/solid_errors/install/templates/create_solid_errors_tables.rb.erb
@@ -3,9 +3,9 @@
 class CreateSolidErrorsTables < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :solid_errors do |t|
-      t.string :exception_class, null: false
+      t.string :exception_class, null: false, limit: 200
       t.string :message, null: false
-      t.string :severity, null: false
+      t.string :severity, null: false, limit: 25
       t.string :source
       t.datetime :resolved_at, index: true
 


### PR DESCRIPTION
In order to ensure that the uniqueness constraint index is below MySQL's max byte length.

Resolves #1