### PR TITLE
Force :en locale inside ErrorsController to avoid missing translations

### DIFF
--- a/app/controllers/solid_errors/errors_controller.rb
+++ b/app/controllers/solid_errors/errors_controller.rb
@@ -1,5 +1,7 @@
 module SolidErrors
   class ErrorsController < ApplicationController
+    around_action :force_english_locale!
+
     before_action :set_error, only: %i[show update]
 
     # GET /errors
@@ -33,6 +35,10 @@ module SolidErrors
 
     def set_error
       @error = Error.find(params[:id])
+    end
+
+    def force_english_locale!(&action)
+      I18n.with_locale(:en, &action)
     end
   end
 end


### PR DESCRIPTION
Fix #34 

When the application is running using a default locale other than :en and not using :en as one of its fallbacks, the time presented inside the errors views will all be showing translation missing messages because the engine is using the custom "datetime.distance_in_words.short" translation set, which doesn't exist on rails-i18n.