### PR TITLE
Avoid triggering N+1 on index page

### DIFF
--- a/app/controllers/solid_errors/errors_controller.rb
+++ b/app/controllers/solid_errors/errors_controller.rb
@@ -11,7 +11,9 @@ module SolidErrors
 
       @errors = Error.unresolved
         .joins(:occurrences)
-        .select(errors_table[Arel.star], occurrences_table[:created_at].maximum.as("recent_occurrence"))
+        .select(errors_table[Arel.star],
+          occurrences_table[:created_at].maximum.as("recent_occurrence"),
+          occurrences_table[:id].count.as("occurrences_count"))
         .group(errors_table[:id])
         .order(recent_occurrence: :desc)
     end

--- a/app/views/solid_errors/errors/_row.html.erb
+++ b/app/views/solid_errors/errors/_row.html.erb
@@ -11,10 +11,10 @@
     <pre class="whitespace-pre-wrap ml-6 mt-4"><%= error.message %></pre>
   </td>
   <td scope="col" class="whitespace-nowrap px-3 py-4 pt-7 text-gray-500 text-right">
-    <%= error.occurrences.size %>
+    <%= error.occurrences_count %>
   </td>
   <td scope="col" class="whitespace-nowrap px-3 py-4 pt-7 text-gray-500 text-right">
-    <% last_seen_at = error.occurrences.maximum(:created_at) %>
+    <% last_seen_at = error.recent_occurrence %>
     <abbr title="<%= last_seen_at.iso8601 %>" class="cursor-help">
       <%= time_tag last_seen_at, time_ago_in_words(last_seen_at, scope: 'datetime.distance_in_words.short') %>
     </abbr>


### PR DESCRIPTION
I noticed a couple of N+1, namely:
* `recent_occurrence` is being computed but never used
* `occurrences.size` is not being computed, triggers N+1

To test it, I created a couple of exceptions locally
<img width="1620" alt="image" src="https://github.com/fractaledmind/solid_errors/assets/112706/acd49534-d467-426e-be6e-0aee629ec3bb">

Queries before:

```
web        |   SolidErrors::Error Load (2.0ms)  SELECT "solid_errors".*, MAX("solid_errors_occurrences"."created_at") AS recent_occurrence FROM "solid_errors" INNER JOIN "solid_errors_occurrences" ON "solid_errors_occurrences"."error_id" = "solid_errors"."id" WHERE "solid_errors"."resolved_at" IS NULL GROUP BY "solid_errors"."id" ORDER BY "recent_occurrence" DESC
web        |   SolidErrors::Occurrence Count (0.6ms)  SELECT COUNT(*) FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 4]]
web        |   SolidErrors::Occurrence Maximum (0.2ms)  SELECT MAX("solid_errors_occurrences"."created_at") FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 4]]
web        |   SolidErrors::Occurrence Count (0.2ms)  SELECT COUNT(*) FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 3]]
web        |   SolidErrors::Occurrence Maximum (0.2ms)  SELECT MAX("solid_errors_occurrences"."created_at") FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 3]]
web        |   SolidErrors::Occurrence Count (0.3ms)  SELECT COUNT(*) FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 2]]
web        |   SolidErrors::Occurrence Maximum (0.2ms)  SELECT MAX("solid_errors_occurrences"."created_at") FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 2]]
web        |   SolidErrors::Occurrence Count (0.3ms)  SELECT COUNT(*) FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 1]]
web        |   SolidErrors::Occurrence Maximum (0.1ms)  SELECT MAX("solid_errors_occurrences"."created_at") FROM "solid_errors_occurrences" WHERE "solid_errors_occurrences"."error_id" = $1  [["error_id", 1]]
```

after:
```
web        |   SolidErrors::Error Load (0.5ms)  SELECT "solid_errors".*, MAX("solid_errors_occurrences"."created_at") AS recent_occurrence, COUNT("solid_errors_occurrences"."id") AS occurrences_count FROM "solid_errors" INNER JOIN "solid_errors_occurrences" ON "solid_errors_occurrences"."error_id" = "solid_errors"."id" WHERE "solid_errors"."resolved_at" IS NULL GROUP BY "solid_errors"."id" ORDER BY "recent_occurrence" DESC
```