### PR TITLE
Update README.md with rails error reporting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Please consult the [official guides](https://guides.rubyonrails.org/error_report
 
 There are intentionally few features; you can view and resolve errors. That’s it. The goal is to provide a simple, lightweight, and performant solution for tracking exceptions in your Rails application. If you need more features, you should probably use a 3rd party service like [Honeybadger](https://www.honeybadger.io/), whose MIT-licensed [Ruby agent gem](https://github.com/honeybadger-io/honeybadger-ruby) provided a couple of critical pieces of code for this project.
 
+### Manually reporting an Error
+
+Errors can be added to Solid Errors via the Rails error reporting API:
+
+```ruby
+Rails.error.report(error)
+```
+
 ### Configuration
 
 You can configure Solid Errors via the Rails configuration object, under the `solid_errors` key. Currently, 6 configuration options are available:


### PR DESCRIPTION
I think it would be helpful for beginners to give an example of the rails error reporting API. That hopefully gives them the hint to read and use the Rails API. 

Maybe it's just me who likes to fly through the README code examples instead of reading it, but I already went into the source code to find out how to manually report one. 