### PR TITLE
Lastest occurrences first in `SolidErrors::ErrorsController#show`

### DIFF
--- a/app/controllers/solid_errors/errors_controller.rb
+++ b/app/controllers/solid_errors/errors_controller.rb
@@ -21,7 +21,7 @@ module SolidErrors
     # GET /errors/1
     def show
       @page = Page.new(@error.occurrences, params)
-      @occurrences = @error.occurrences.offset(@page.offset).limit(@page.items)
+      @occurrences = @error.occurrences.offset(@page.offset).limit(@page.items).order(created_at: :desc)
     end
 
     # PATCH/PUT /errors/1


### PR DESCRIPTION
Hello, I would like to suggest prioritizing the return of occurrences starting with the most recent ones.

<details><summary>Details</summary>
<p>

## Before 

![Screenshot 2024-05-10 at 15 20 58](https://github.com/fractaledmind/solid_errors/assets/7858787/11b41cab-25aa-4e1e-89aa-946d0d0512f4)

## After

![Screenshot 2024-05-10 at 15 20 11](https://github.com/fractaledmind/solid_errors/assets/7858787/bfb980c7-85ad-4c1b-a01c-487c24d37763)

</p>
</details> 

