### PR TITLE
Fix partial not being found with different inflector

### DIFF
--- a/app/views/solid_errors/occurrences/_collection.html.erb
+++ b/app/views/solid_errors/occurrences/_collection.html.erb
@@ -49,7 +49,8 @@
 
   <div class="min-w-full">
     <% if occurrences.any? %>
-      <%= render occurrences %>
+      <%= render partial: "solid_errors/occurrences/occurrence",
+            collection: occurrences, as: :occurrence %>
     <% else %>
       <div class="flex items-center justify-center gap-2">
         <%= bootstrap_svg "list-ul" %>


### PR DESCRIPTION
I tried installing solid_errors on a spanish language project, it has inflection rules like:

```ruby
ActiveSupport::Inflector.inflections do |inflect|
  inflect.plural /([aeiou])([A-Z]|_|$)/, '\1s\2'
  inflect.plural /([rlnd])([A-Z]|_|$)/, '\1es\2'
  inflect.plural /([aeiou])([A-Z]|_|$)([a-z]+)([rlnd])($)/, '\1s\2\3\4es\5'
  inflect.plural /([rlnd])([A-Z]|_|$)([a-z]+)([aeiou])($)/, '\1es\2\3\4s\5'
end
```
This causes the render of occurrences to look for the partial under the `solid_errores` path

This PR uses the full version of the render method
