### PR TITLE
Fix rails 8 warning: "Drawing a route with a hash key name is deprecated"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 SolidErrors::Engine.routes.draw do
-  get "/" => "errors#index", :as => :root
+  get "/", to: "errors#index", as: :root
 
   resources :errors, only: [:index, :show, :update, :destroy], path: ""
 end


### PR DESCRIPTION
```
DEPRECATION WARNING: Drawing a route with a hash key name is deprecated and will be removed in Rails 8.1. Please use the `to:` option with "controller#action" syntax instead. Instead of: match "path" => "controller#action` Please use: match "path", to: "controller#action" (called from <top (required)> at /Users/dorianmariefr/src/dorianmariecom/code/config/environment.rb:7) /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/mapper.rb:798:in `map_method'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/mapper.rb:741:in `get'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/solid_errors-0.5.0/config/routes.rb:2:in `block in <top (required)>'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/mapper.rb:677:in `instance_exec'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/mapper.rb:677:in `block in with_default_scope'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/mapper.rb:933:in `scope'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/mapper.rb:676:in `with_default_scope'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/route_set.rb:477:in `eval_block'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/actionpack/lib/action_dispatch/routing/route_set.rb:461:in `draw'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/engine/lazy_route_set.rb:73:in `draw'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/solid_errors-0.5.0/config/routes.rb:1:in `<top (required)>'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:60:in `load'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:60:in `block in load_paths'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:60:in `each'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:60:in `load_paths'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:26:in `reload!'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:48:in `block in updater'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/activesupport/lib/active_support/file_update_checker.rb:85:in `execute'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:13:in `execute'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/routes_reloader.rb:35:in `execute_unless_loaded'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application/finisher.rb:180:in `block in <module:Finisher>'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/initializable.rb:32:in `instance_exec'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/initializable.rb:32:in `run'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/initializable.rb:61:in `block in run_initializers'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:231:in `block in tsort_each'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:353:in `block (2 levels) in each_strongly_connected_component'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:434:in `each_strongly_connected_component_from'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:352:in `block in each_strongly_connected_component'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `each'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `call'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:350:in `each_strongly_connected_component'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:229:in `tsort_each'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/tsort.rb:208:in `tsort_each'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/initializable.rb:60:in `run_initializers'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/bundler/gems/rails-c6e3336cfdec/railties/lib/rails/application.rb:440:in `initialize!'
  /Users/dorianmariefr/src/dorianmariecom/code/config/environment.rb:7:in `<top (required)>'
  /Users/dorianmariefr/src/dorianmariecom/code/spec/rails_helper.rb:7:in `require_relative'
  /Users/dorianmariefr/src/dorianmariecom/code/spec/rails_helper.rb:7:in `<top (required)>'
  <internal:/Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
  <internal:/Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
  /Users/dorianmariefr/src/dorianmariecom/code/spec/features/generate_and_evaluate_program_spec.rb:3:in `<top (required)>'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2138:in `load'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:2138:in `load_file_handling_errors'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:1638:in `block in load_spec_files'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:1636:in `each'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/configuration.rb:1636:in `load_spec_files'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:102:in `setup'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:86:in `run'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:71:in `run'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/lib/rspec/core/runner.rb:45:in `invoke'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.0/exe/rspec:4:in `<top (required)>'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/bin/rspec:25:in `load'
  /Users/dorianmariefr/.asdf/installs/ruby/3.3.4/bin/rspec:25:in `<main>'
```