### PR TITLE
Add clickable email links for viewing errors online

### DIFF
--- a/app/views/solid_errors/errors/_error.html.erb
+++ b/app/views/solid_errors/errors/_error.html.erb
@@ -10,7 +10,9 @@
     <% end %>
 
     <small class="text-base">
-      #<code><%= error.id %></code>
+      <code>
+        <%= link_to_if Rails.application.config.action_mailer.default_url_options[:host].present?, "##{error.id}", error_url(error) %>
+      </code>
     </small>
   </div>
 

--- a/app/views/solid_errors/errors/_error.html.erb
+++ b/app/views/solid_errors/errors/_error.html.erb
@@ -9,11 +9,9 @@
       <em><code><%= error.source %></code></em>
     <% end %>
 
-    <small class="text-base">
-      <code>
-        <%= link_to_if Rails.application.config.action_mailer.default_url_options[:host].present?, "##{error.id}", error_url(error) %>
-      </code>
-    </small>
+    <div>
+      <%= link_to_if Rails.application.config.action_mailer.default_url_options[:host].present?, "##{error.id}", error_url(error), class: "text-blue-400 underline" %>
+    </div>
   </div>
 
   <pre class="whitespace-pre-wrap"><%= error.message %></pre>


### PR DESCRIPTION
When I open email with the new error I want to be able to view current status online (was it already resolved?)

- link_to error **only** if default_url_options[:host] is configured for ActionMailer
- removes obsolete empty plain text template (Email is HTML format only)


![Screenshot 2024-09-22 at 21 09 24](https://github.com/user-attachments/assets/34f4e80c-e992-4eab-be80-45c83b54b25b)


