### PR TITLE
configuration for a subject prefix for email

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ You can configure Solid Errors via the Rails configuration object, under the `so
 * `email_from` - The email address to send a notification from. See [Email notifications](#email-notifications) for more information.
 * `email_to` - The email address(es) to send a notification to. See [Email notifications](#email-notifications) for more information.
 * `email_subject_prefix` - Prefix added to the subject line for email notifications. See [Email notifications](#email-notifications) for more information.
+
 #### Database Configuration
 
 `config.solid_errors.connects_to` takes a custom database configuration hash that will be used in the abstract `SolidErrors::Record` Active Record model. This is required to use a different database than the main app. For example:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ There are two ways to configure email notifications. First, you can use environm
 ENV["SOLIDERRORS_SEND_EMAILS"] = true # defaults to false
 ENV["SOLIDERRORS_EMAIL_FROM"] = "errors@myapp.com" # defaults to "solid_errors@noreply.com"
 ENV["SOLIDERRORS_EMAIL_TO"] = "devs@myapp.com" # no default, must be set
-ENV["SOLIDERRORS_EMAIL_SUBJECT_PREFIX"] = "[Application name][Application environment]" # no default, optional
+ENV["SOLIDERRORS_EMAIL_SUBJECT_PREFIX"] = "[Application name][Environment]" # no default, optional
 ```
 
 Second, you can set the values via the configuration object:

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can configure Solid Errors via the Rails configuration object, under the `so
 * `sends_email` - Whether or not to send emails when an error occurs. See [Email notifications](#email-notifications) for more information.
 * `email_from` - The email address to send a notification from. See [Email notifications](#email-notifications) for more information.
 * `email_to` - The email address(es) to send a notification to. See [Email notifications](#email-notifications) for more information.
-
+* `email_subject_prefix` - The subject prefix to use for email notifications. See [Email notifications](#email-notifications) for more information.
 #### Database Configuration
 
 `config.solid_errors.connects_to` takes a custom database configuration hash that will be used in the abstract `SolidErrors::Record` Active Record model. This is required to use a different database than the main app. For example:
@@ -208,7 +208,7 @@ end
 
 #### Email notifications
 
-Solid Errors _can_ send email notifications whenever an error occurs, if your application has ActionMailer already properly setup to send emails. However, in order to activate this feature you must define the email address(es) to send the notifications to. Optionally, you can also define the email address to send the notifications from (useful if your email provider only allows emails to be sent from a predefined list of addresses) or simply turn off this feature altogether.
+Solid Errors _can_ send email notifications whenever an error occurs, if your application has ActionMailer already properly setup to send emails. However, in order to activate this feature you must define the email address(es) to send the notifications to. Optionally, you can also define the email address to send the notifications from (useful if your email provider only allows emails to be sent from a predefined list of addresses) or simply turn off this feature altogether. You can also define a subject prefix for the email notifications to quickly identify the source of the error.
 
 There are two ways to configure email notifications. First, you can use environment variables:
 
@@ -216,15 +216,17 @@ There are two ways to configure email notifications. First, you can use environm
 ENV["SOLIDERRORS_SEND_EMAILS"] = true # defaults to false
 ENV["SOLIDERRORS_EMAIL_FROM"] = "errors@myapp.com" # defaults to "solid_errors@noreply.com"
 ENV["SOLIDERRORS_EMAIL_TO"] = "devs@myapp.com" # no default, must be set
+ENV["SOLIDERRORS_EMAIL_SUBJECT_PREFIX"] = "[Application name][Application environment]" # no default, optional
 ```
 
 Second, you can set the values via the configuration object:
 
 ```ruby
-# Set authentication credentials for Solid Errors
+# Set authentication credentials and optional subject prefix for Solid Errors
 config.solid_errors.send_emails = true
 config.solid_errors.email_from = "errors@myapp.com"
 config.solid_errors.email_to = "devs@myapp.com"
+config.solid_errors.email_subject_prefix = "[#{Rails.application.name}][#{Rails.env}]"
 ```
 
 If you have set `send_emails` to `true` and have set an `email_to` address, Solid Errors will send an email notification whenever an error occurs. If you have not set `send_emails` to `true` or have not set an `email_to` address, Solid Errors will not send any email notifications.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can configure Solid Errors via the Rails configuration object, under the `so
 * `sends_email` - Whether or not to send emails when an error occurs. See [Email notifications](#email-notifications) for more information.
 * `email_from` - The email address to send a notification from. See [Email notifications](#email-notifications) for more information.
 * `email_to` - The email address(es) to send a notification to. See [Email notifications](#email-notifications) for more information.
-* `email_subject_prefix` - The subject prefix to use for email notifications. See [Email notifications](#email-notifications) for more information.
+* `email_subject_prefix` - Prefix added to the subject line for email notifications. See [Email notifications](#email-notifications) for more information.
 #### Database Configuration
 
 `config.solid_errors.connects_to` takes a custom database configuration hash that will be used in the abstract `SolidErrors::Record` Active Record model. This is required to use a different database than the main app. For example:

--- a/app/mailers/solid_errors/error_mailer.rb
+++ b/app/mailers/solid_errors/error_mailer.rb
@@ -5,7 +5,9 @@ module SolidErrors
       @occurrence = occurrence
       @error = occurrence.error
       subject = "#{@error.severity_emoji} #{@error.exception_class}"
-      subject.prepend(SolidErrors.email_subject_prefix) if SolidErrors.email_subject_prefix.present?
+      if SolidErrors.email_subject_prefix.present?
+        subject = [SolidErrors.email_subject_prefix, subject].join(" ").squish!
+      end
       mail(
         subject: subject,
         from: SolidErrors.email_from,

--- a/app/mailers/solid_errors/error_mailer.rb
+++ b/app/mailers/solid_errors/error_mailer.rb
@@ -4,9 +4,10 @@ module SolidErrors
     def error_occurred(occurrence)
       @occurrence = occurrence
       @error = occurrence.error
-
+      subject = "#{@error.severity_emoji} #{@error.exception_class}"
+      subject.prepend(SolidErrors.subject_prefix) if SolidErrors.subject_prefix.present?
       mail(
-        subject: "#{SolidErrors.subject_prefix} #{@error.severity_emoji} #{@error.exception_class}",
+        subject: subject,
         from: SolidErrors.email_from,
         to: SolidErrors.email_to
       )

--- a/app/mailers/solid_errors/error_mailer.rb
+++ b/app/mailers/solid_errors/error_mailer.rb
@@ -5,7 +5,7 @@ module SolidErrors
       @occurrence = occurrence
       @error = occurrence.error
       subject = "#{@error.severity_emoji} #{@error.exception_class}"
-      subject.prepend(SolidErrors.subject_prefix) if SolidErrors.subject_prefix.present?
+      subject.prepend(SolidErrors.email_subject_prefix) if SolidErrors.email_subject_prefix.present?
       mail(
         subject: subject,
         from: SolidErrors.email_from,

--- a/app/mailers/solid_errors/error_mailer.rb
+++ b/app/mailers/solid_errors/error_mailer.rb
@@ -6,7 +6,7 @@ module SolidErrors
       @error = occurrence.error
 
       mail(
-        subject: "#{@error.severity_emoji} #{@error.exception_class}",
+        subject: "#{SolidErrors.subject_prefix} #{@error.severity_emoji} #{@error.exception_class}",
         from: SolidErrors.email_from,
         to: SolidErrors.email_to
       )

--- a/lib/solid_errors.rb
+++ b/lib/solid_errors.rb
@@ -12,7 +12,7 @@ module SolidErrors
   mattr_writer :send_emails
   mattr_writer :email_from
   mattr_writer :email_to
-  mattr_writer :subject_prefix
+  mattr_writer :email_subject_prefix
 
   class << self
     # use method instead of attr_accessor to ensure
@@ -39,8 +39,8 @@ module SolidErrors
       @email_to ||= ENV["SOLIDERRORS_EMAIL_TO"] || @@email_to
     end
 
-    def subject_prefix
-      @subject_prefix ||= ENV["SOLIDERRORS_SUBJECT_PREFIX"] || @@subject_prefix
+    def email_subject_prefix
+      @email_subject_prefix ||= ENV["SOLIDERRORS_EMAIL_SUBJECT_PREFIX"] || @@email_subject_prefix
     end
   end
 end

--- a/lib/solid_errors.rb
+++ b/lib/solid_errors.rb
@@ -12,6 +12,7 @@ module SolidErrors
   mattr_writer :send_emails
   mattr_writer :email_from
   mattr_writer :email_to
+  mattr_writer :subject_prefix
 
   class << self
     # use method instead of attr_accessor to ensure
@@ -36,6 +37,10 @@ module SolidErrors
 
     def email_to
       @email_to ||= ENV["SOLIDERRORS_EMAIL_TO"] || @@email_to
+    end
+
+    def subject_prefix
+      @subject_prefix ||= ENV["SOLIDERRORS_SUBJECT_PREFIX"] || @@subject_prefix
     end
   end
 end


### PR DESCRIPTION
Added an option to add a subject prefix to the emails sent by solid_errors. Useful when you have multiple apps/environments using solid errors and what to easily filter the email received