### PR TITLE
Introduce base_controller_class config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ You can configure Solid Errors via the Rails configuration object, under the `so
 * `email_from` - The email address to send a notification from. See [Email notifications](#email-notifications) for more information.
 * `email_to` - The email address(es) to send a notification to. See [Email notifications](#email-notifications) for more information.
 * `email_subject_prefix` - Prefix added to the subject line for email notifications. See [Email notifications](#email-notifications) for more information.
+* `base_controller_class` - Specify a different controller as the base class for the Solid Errors controller. See [Authentication](#authentication) for more information.
 
 #### Database Configuration
 
@@ -205,6 +206,13 @@ If you use Devise for authentication in your app, you can also restrict access t
 authenticate :user, -> (user) { user.admin? } do
   mount SolidErrors::Engine, at: "/solid_errors"
 end
+```
+
+You can also specify a different controller to use as the Solid Errors controller base class:
+
+```ruby
+# Override the base controller class with your own controller
+config.solid_errors.base_controller_class = "YourAdminController"
 ```
 
 #### Email notifications

--- a/app/controllers/solid_errors/application_controller.rb
+++ b/app/controllers/solid_errors/application_controller.rb
@@ -1,5 +1,6 @@
 module SolidErrors
-  class ApplicationController < ActionController::Base
+  class ApplicationController < SolidErrors.base_controller_class.constantize
+    layout "solid_errors/application"
     protect_from_forgery with: :exception
 
     http_basic_authenticate_with name: SolidErrors.username, password: SolidErrors.password if SolidErrors.password

--- a/lib/solid_errors.rb
+++ b/lib/solid_errors.rb
@@ -7,6 +7,7 @@ require_relative "solid_errors/engine"
 
 module SolidErrors
   mattr_accessor :connects_to
+  mattr_accessor :base_controller_class, default: "::ActionController::Base"
   mattr_writer :username
   mattr_writer :password
   mattr_writer :send_emails
@@ -21,8 +22,6 @@ module SolidErrors
       @username ||= ENV["SOLIDERRORS_USERNAME"] || @@username
     end
 
-    # use method instead of attr_accessor to ensure
-    # this works if variable set after SolidErrors is loaded
     def password
       @password ||= ENV["SOLIDERRORS_PASSWORD"] || @@password
     end

--- a/test/test_solid_errors.rb
+++ b/test/test_solid_errors.rb
@@ -6,4 +6,8 @@ class TestSolidErrors < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::SolidErrors::VERSION
   end
+
+  def test_default_base_controller
+    assert_equal ActionController::Base, SolidErrors::ApplicationController.superclass
+  end
 end


### PR DESCRIPTION
Motivation:

It would be nice to use a specific controller from my application as the Solid Errors base controller, the same way that [Mission Control Jobs](https://github.com/rails/mission_control-jobs?tab=readme-ov-file#authentication-and-base-controller-class) does. For example, if `MyAdminController` handles all of my authentication, it would be nice to simply tell Solid Errors to inherit from that controller.

Details:

This PR adds a new `base_controller_class` config option to accomplish this.

Please let me know if this is something you'd be willing to add, and if there any other aspects you'd like me to include or change. 

**And thank you for Solid Errors!** Today I upgraded our production app to use Solid Errors ✌🏼