### PR TITLE
Fix console `uninitialized constant Rails` error

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require "rails"
 require "solid_errors"
 
 # You can add fixtures and/or initialization code here to make experimenting


### PR DESCRIPTION
This PR address the following error that was present when executing `bin/console`:

> solid_errors/lib/solid_errors/engine.rb:4:in `<module:SolidErrors>': uninitialized constant Rails (NameError)
>   class Engine < ::Rails::Engine
> 