### PR TITLE
Remove ActionMailer as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "rake", "~> 13.0"
 gem "minitest", "~> 5.0"
 
 gem "standard", "~> 1.3"
+
+gem "actionmailer", ">= 7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     solid_errors (0.6.1)
-      actionmailer (>= 7.0)
       actionpack (>= 7.0)
       actionview (>= 7.0)
       activerecord (>= 7.0)
@@ -63,7 +62,7 @@ GEM
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
-    date (3.3.4)
+    date (3.4.1)
     drb (2.2.1)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -88,14 +87,14 @@ GEM
       net-smtp
     mini_mime (1.1.5)
     minitest (5.25.1)
-    net-imap (0.4.14)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
@@ -188,6 +187,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  actionmailer (>= 7.0)
   minitest (~> 5.0)
   rake (~> 13.0)
   solid_errors!

--- a/app/mailers/solid_errors/error_mailer.rb
+++ b/app/mailers/solid_errors/error_mailer.rb
@@ -1,7 +1,10 @@
 module SolidErrors
   # adapted from: https://github.com/codergeek121/email_error_reporter/blob/main/lib/email_error_reporter/error_mailer.rb
-  class ErrorMailer < ActionMailer::Base
+  class ErrorMailer < (defined?(ActionMailer::Base) ? ActionMailer::Base : Object)
     def error_occurred(occurrence)
+      unless defined?(ActionMailer::Base)
+        raise "ActionMailer is not available. Make sure that you require \"action_mailer/railtie\" in application.rb"
+      end
       @occurrence = occurrence
       @error = occurrence.error
       subject = "#{@error.severity_emoji} #{@error.exception_class}"

--- a/lib/solid_errors/engine.rb
+++ b/lib/solid_errors/engine.rb
@@ -10,6 +10,11 @@ module SolidErrors
       config.solid_errors.each do |name, value|
         SolidErrors.public_send(:"#{name}=", value)
       end
+
+      if SolidErrors.send_emails? && !defined?(ActionMailer)
+        raise "You have configured solid_errors.send_emails = true but ActionMailer is not available." \
+              "Make sure that you require \"action_mailer/railtie\" in application.rb or set solid_errors.send_emails = false."
+      end
     end
 
     initializer "solid_errors.active_record.error_subscriber" do

--- a/solid_errors.gemspec
+++ b/solid_errors.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   end
 
   ">= 7.0".tap do |rails_version|
-    spec.add_dependency "actionmailer", rails_version
     spec.add_dependency "actionpack", rails_version
     spec.add_dependency "actionview", rails_version
     spec.add_dependency "activerecord", rails_version


### PR DESCRIPTION
Closes #76 

This PR aims to remove ActionMailer as a dependency so solid_errors can be used also in Rails Apps that don't have it as a dependency. I find `solid_errors` a perfect solution for my smaller projects, and many of them don't actually send emails so  `require "action_mailer/railtie"` is commented out in `application.rb`